### PR TITLE
Add ability to have a go struct field as both a field and a tag in influx

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -72,8 +72,8 @@ func decode(columns []string, values [][]interface{}, result interface{}) error 
 				continue
 			}
 
-			tag = getInfluxFieldTagName(tag)
-			i, ok := colIndex[tag]
+			fieldData := getInfluxFieldTagData(f.String(), tag)
+			i, ok := colIndex[fieldData.fieldName]
 
 			if !ok {
 				continue
@@ -86,12 +86,12 @@ func decode(columns []string, values [][]interface{}, result interface{}) error 
 			if f.Type() == reflect.TypeOf(time.Time{}) {
 				timeS, ok := vIn[i].(string)
 				if !ok {
-					e := errors.New("Time input is not string")
+					e := errors.New("time input is not string")
 					errs = appendErrors(errs, e)
 				} else {
 					time, err := time.Parse(time.RFC3339, timeS)
 					if err != nil {
-						e := errors.New("Error parsing time")
+						e := errors.New("error parsing time")
 						errs = appendErrors(errs, e)
 					} else {
 						vIn[i] = time

--- a/decode_test.go
+++ b/decode_test.go
@@ -88,10 +88,8 @@ func TestDecodeMissingColumn(t *testing.T) {
 	decoded := []DecodeType{}
 
 	err := decode(columns, values, &decoded)
-	if err == nil {
-		t.Error("Expected error decoding: ", err)
-	} else {
-		fmt.Println("Got expected error: ", err)
+	if err != nil {
+		t.Error("UnExpected error decoding: ", columns, values, &decoded)
 	}
 
 	if !reflect.DeepEqual(expected, decoded) {

--- a/encode.go
+++ b/encode.go
@@ -2,12 +2,12 @@ package influxdbhelper
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"time"
 )
 
-func encode(d interface{}) (t time.Time, tags map[string]string,
-	fields map[string]interface{}, err error) {
+func encode(d interface{}) (t time.Time, tags map[string]string, fields map[string]interface{}, err error) {
 	tags = make(map[string]string)
 	fields = make(map[string]interface{})
 	dValue := reflect.ValueOf(d)
@@ -18,25 +18,26 @@ func encode(d interface{}) (t time.Time, tags map[string]string,
 
 	for i := 0; i < dValue.NumField(); i++ {
 		f := dValue.Field(i)
+		fieldName := dValue.Type().Field(i).Name
 		fieldTag := dValue.Type().Field(i).Tag.Get("influx")
+		fieldData := getInfluxFieldTagData(fieldName, fieldTag)
 
-		isTag := isInfluxTag(fieldTag)
-		name := getInfluxFieldTagName(fieldTag)
-
-		if name == "-" {
+		if fieldData.fieldName == "-" {
 			continue
 		}
 
-		if name == "time" {
+		if fieldData.fieldName == "time" {
 			// TODO error checking
 			t = f.Interface().(time.Time)
 			continue
 		}
 
-		if isTag {
-			tags[name] = f.String()
-		} else {
-			fields[name] = f.Interface()
+		if fieldData.isTag {
+			tags[fieldData.fieldName] = fmt.Sprintf("%v", f)
+		}
+
+		if fieldData.isField {
+			fields[fieldData.fieldName] = f.Interface()
 		}
 	}
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -15,36 +15,43 @@ func TestEncodeDataNotStruct(t *testing.T) {
 
 func TestEncode(t *testing.T) {
 	type MyType struct {
-		Time         time.Time `influx:"time"`
-		TagValue     string    `influx:"tagValue,tag"`
-		IntValue     int       `influx:"intValue"`
-		FloatValue   float64   `influx:"floatValue"`
-		BoolValue    bool      `influx:"boolValue"`
-		StringValue  string    `influx:"stringValue"`
-		IgnoredValue string    `influx:"-"`
+		Time             time.Time `influx:"time"`
+		TagValue         string    `influx:"tagValue,tag"`
+		TagAndFieldValue string    `influx:"tagAndFieldValue,tag,field"`
+		IntValue         int       `influx:"intValue"`
+		FloatValue       float64   `influx:"floatValue"`
+		BoolValue        bool      `influx:"boolValue"`
+		StringValue      string    `influx:"stringValue"`
+		StructFieldName  string    `influx:""`
+		IgnoredValue     string    `influx:"-"`
 	}
 
 	d := MyType{
 		time.Now(),
 		"tag-value",
+		"tag-and-field-value",
 		10,
 		10.5,
 		true,
 		"string",
+		"struct-field",
 		"ignored",
 	}
 
 	timeExp := d.Time
 
 	tagsExp := map[string]string{
-		"tagValue": "tag-value",
+		"tagValue":         "tag-value",
+		"tagAndFieldValue": "tag-and-field-value",
 	}
 
 	fieldsExp := map[string]interface{}{
-		"intValue":    d.IntValue,
-		"floatValue":  d.FloatValue,
-		"boolValue":   d.BoolValue,
-		"stringValue": d.StringValue,
+		"tagAndFieldValue": d.TagAndFieldValue,
+		"intValue":         d.IntValue,
+		"floatValue":       d.FloatValue,
+		"boolValue":        d.BoolValue,
+		"stringValue":      d.StringValue,
+		"StructFieldName":  d.StructFieldName,
 	}
 
 	tm, tags, fields, err := encode(d)

--- a/examples/writeread.go
+++ b/examples/writeread.go
@@ -48,7 +48,7 @@ type envSample struct {
 type envSampleRead struct {
 	Time        time.Time `influx:"time"`
 	Location    string    `influx:"location,tag"`
-	City        string    `influx:"city,tag"`
+	City        string    `influx:"city,tag,field"`
 	Temperature float64   `influx:"temperature"`
 	Humidity    float64   `influx:"humidity"`
 	Cycles      float64   `influx:"cycles"`

--- a/tag.go
+++ b/tag.go
@@ -2,26 +2,32 @@ package influxdbhelper
 
 import "strings"
 
-func isInfluxTag(structTag string) bool {
+type influxFieldTagData struct {
+	fieldName string
+	isTag     bool
+	isField   bool
+}
+
+func getInfluxFieldTagData(fieldName, structTag string) (fieldData *influxFieldTagData) {
+	fieldData = &influxFieldTagData{fieldName: fieldName}
 	parts := strings.Split(structTag, ",")
+	fieldName, parts = parts[0], parts[1:]
+	if fieldName != "" {
+		fieldData.fieldName = fieldName
+	}
 
 	for _, part := range parts {
 		if part == "tag" {
-			return true
+			fieldData.isTag = true
+		}
+		if part == "field" {
+			fieldData.isField = true
 		}
 	}
 
-	return false
-}
-
-func getInfluxFieldTagName(structTag string) string {
-	parts := strings.Split(structTag, ",")
-
-	for _, part := range parts {
-		if part != "tag" {
-			return part
-		}
+	if !fieldData.isField && !fieldData.isTag {
+		fieldData.isField = true
 	}
 
-	return ""
+	return
 }

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,0 +1,38 @@
+package influxdbhelper
+
+import "testing"
+
+func TestTag(t *testing.T) {
+	data := []struct {
+		fieldTag        string
+		structFieldName string
+		fieldName       string
+		isTag           bool
+		isField         bool
+	}{
+		{"", "Test", "Test", false, true},
+		{"", "Test", "Test", false, true},
+		{",tag", "Test", "Test", true, false},
+		{",field,tag", "Test", "Test", true, true},
+		{",tag,field", "Test", "Test", true, true},
+		{",field", "Test", "Test", false, true},
+		{"test", "Test", "test", false, true},
+		{"test,tag", "Test", "test", true, false},
+		{"test,field,tag", "Test", "test", true, true},
+		{"test,tag,field", "Test", "test", true, true},
+		{"test,field", "Test", "test", false, true},
+	}
+
+	for _, testData := range data {
+		fieldData := getInfluxFieldTagData(testData.structFieldName, testData.fieldTag)
+		if fieldData.fieldName != testData.fieldName {
+			t.Errorf("%v != %v", fieldData.fieldName, testData.fieldName)
+		}
+		if fieldData.isField != testData.isField {
+			t.Errorf("%v != %v", fieldData.isField, testData.isField)
+		}
+		if fieldData.isTag != testData.isTag {
+			t.Errorf("%v != %v", fieldData.isTag, testData.isTag)
+		}
+	}
+}


### PR DESCRIPTION
some python code I am converting to go was sending data like
```
{
    "measurement": "test",
    "tags": {
        ...
        "Push_TimeStamp": testResultPushTimeStamp
    },
    "fields": {
        ...
        "Push_TimeStamp": testResultPushTimeStamp,
    }
}
```

And I did not want to be hand coding the push data so I needed the ability to set a go struct field as both a field and tag in influxdb