### PR TITLE
Major Refactor

### DIFF
--- a/client.go
+++ b/client.go
@@ -145,7 +145,6 @@ func (c *helperClient) DecodeQuery(q string, result interface{}) (err error) {
 
 	var response *influxClient.Response
 	response, err = c.client.Query(query)
-	c.using = nil
 
 	if response.Error() != nil {
 		return response.Error()
@@ -208,7 +207,6 @@ func (c *helperClient) WritePointTagsFields(tags map[string]string, fields map[s
 	}
 
 	pt, err := influxClient.NewPoint(c.using.measurement, tags, fields, t)
-	c.using = nil
 
 	if err != nil {
 		return err

--- a/client.go
+++ b/client.go
@@ -25,8 +25,11 @@ type Client interface {
 	// UseDB sets the DB to use for Query, WritePoint, and WritePointTagsFields
 	UseDB(db string) Client
 
-	// UseMeasurement sets the measurment to use for WritePoint, and WritePointTagsFields
+	// UseMeasurement sets the measurement to use for WritePoint, and WritePointTagsFields
 	UseMeasurement(measurement string) Client
+
+	// UseTimeField sets the time field to use for WritePoint, and WritePointTagsFields
+	UseTimeField(fieldName string) Client
 
 	// Query executes an InfluxDb query, and unpacks the result into the
 	// result data structure.

--- a/client_test.go
+++ b/client_test.go
@@ -23,7 +23,7 @@ func ExampleClient_WritePoint() {
 		Id:          "12432as32",
 	}
 
-	c.WritePoint("myDb", "test", s)
+	c.UseDB("myDb").UseMeasurement("test").WritePoint(s)
 }
 
 func ExampleClient_Query() {
@@ -41,7 +41,7 @@ func ExampleClient_Query() {
 
 	q := `SELECT * FROM test ORDER BY time DESC LIMIT 10`
 
-	c.Query("myDb", q, &samplesRead)
+	c.UseDB("myDb").DecodeQuery(q, &samplesRead)
 
 	// samplesRead is now populated with data from InfluxDb
 }

--- a/decode.go
+++ b/decode.go
@@ -72,8 +72,8 @@ func decode(columns []string, values [][]interface{}, result interface{}) error 
 				continue
 			}
 
-			tag = getInfluxFieldTagName(tag)
-			i, ok := colIndex[tag]
+			fieldData := getInfluxFieldTagData(f.String(), tag)
+			i, ok := colIndex[fieldData.fieldName]
 
 			if !ok {
 				continue
@@ -86,12 +86,12 @@ func decode(columns []string, values [][]interface{}, result interface{}) error 
 			if f.Type() == reflect.TypeOf(time.Time{}) {
 				timeS, ok := vIn[i].(string)
 				if !ok {
-					e := errors.New("Time input is not string")
+					e := errors.New("time input is not string")
 					errs = appendErrors(errs, e)
 				} else {
 					time, err := time.Parse(time.RFC3339, timeS)
 					if err != nil {
-						e := errors.New("Error parsing time")
+						e := errors.New("error parsing time")
 						errs = appendErrors(errs, e)
 					} else {
 						vIn[i] = time

--- a/decode.go
+++ b/decode.go
@@ -1,150 +1,56 @@
 package influxdbhelper
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
 	"reflect"
-	"strconv"
 	"time"
+
+	influxModels "github.com/influxdata/influxdb/models"
+	"github.com/mitchellh/mapstructure"
 )
+
+
 
 // Decode is used to process data returned by an InfluxDb query and uses reflection
 // to transform it into an array of structs of type result.
 //
 // This function is used internally by the Query function.
-func decode(columns []string, values [][]interface{}, result interface{}) error {
-	colIndex := map[string]int{}
-	for i, col := range columns {
-		colIndex[col] = i
-	}
+func decode(influxResult influxModels.Row, result interface{}) error {
+	influxData := make([]map[string]interface{}, 0)
 
-	resultV := reflect.ValueOf(result)
-	if resultV.Kind() != reflect.Ptr {
-		return errors.New("result must be ptr")
-	}
-
-	resultSlice := resultV.Elem()
-
-	if !resultSlice.CanAddr() {
-		return errors.New("result must be addressable (a pointer)")
-	}
-
-	if resultSlice.Kind() != reflect.Slice {
-		return errors.New("result must be ptr to slice")
-	}
-
-	resultStruct := resultSlice.Type().Elem()
-	if resultStruct.Kind() != reflect.Struct {
-		return errors.New("result must be slice of structs")
-	}
-
-	numFields := resultStruct.NumField()
-	resultStructFields := []reflect.StructField{}
-	resultStructTags := []string{}
-
-	for i := 0; i < numFields; i++ {
-		f := resultStruct.Field(i)
-		resultStructFields = append(resultStructFields,
-			f)
-		resultStructTags = append(resultStructTags,
-			f.Tag.Get("influx"))
-	}
-
-	// not sure why we need to do this, but we need to Set resultSlice
-	// at the end of this function for things to work
-	resultSliceRet := resultSlice
-
-	// Accumulate any errors
-	errs := make([]string, 0)
-
-	typeError := false
-
-	for _, vIn := range values {
-		vOut := reflect.Indirect(reflect.New(resultStruct))
-		valueCount := 0
-		for i := 0; i < vOut.NumField(); i++ {
-			f := vOut.Field(i)
-			// FIXME, not sure how to get the tags
-			// from vOut
-			tag := resultStructTags[i]
-			if tag == "-" {
-				continue
+	for _, v := range influxResult.Values {
+		r := make(map[string]interface{})
+		for i, c := range influxResult.Columns {
+			if len(v) >= i+1 {
+				r[c] = v[i]
 			}
-
-			fieldData := getInfluxFieldTagData(f.String(), tag)
-			i, ok := colIndex[fieldData.fieldName]
-
-			if !ok {
-				continue
-			}
-
-			if vIn[i] == nil {
-				continue
-			}
-
-			if f.Type() == reflect.TypeOf(time.Time{}) {
-				timeS, ok := vIn[i].(string)
-				if !ok {
-					e := errors.New("time input is not string")
-					errs = appendErrors(errs, e)
-				} else {
-					time, err := time.Parse(time.RFC3339, timeS)
-					if err != nil {
-						e := errors.New("error parsing time")
-						errs = appendErrors(errs, e)
-					} else {
-						vIn[i] = time
-					}
-				}
-			}
-
-			if reflect.TypeOf(vIn[i]) == reflect.TypeOf(json.Number("1")) {
-				if f.Type() == reflect.TypeOf(1.0) {
-					vInJSONNum, _ := vIn[i].(json.Number)
-					vInFloat, err := strconv.ParseFloat(string(vInJSONNum), 64)
-					if err != nil {
-						es := "error converting json.Number"
-						errs = appendErrors(errs, errors.New(es))
-					}
-					vIn[i] = vInFloat
-				} else {
-					vInJSONNum, _ := vIn[i].(json.Number)
-					vInFloat, err := strconv.Atoi(string(vInJSONNum))
-					if err != nil {
-						es := "error converting json.Number"
-						errs = appendErrors(errs, errors.New(es))
-					}
-					vIn[i] = vInFloat
-				}
-			}
-
-			if reflect.TypeOf(vIn[i]) != f.Type() {
-				if !typeError {
-					es := fmt.Sprintf("Type mismatch on decode of %v: %v != %v",
-						vIn[i],
-						reflect.TypeOf(vIn[i]).String(),
-						f.Type().String())
-
-					errs = appendErrors(errs, errors.New(es))
-					typeError = true
-				}
-				continue
-			}
-			f.Set(reflect.ValueOf(vIn[i]))
-			valueCount = 1
 		}
-
-		if valueCount > 0 {
-			resultSliceRet = reflect.Append(resultSliceRet, vOut)
+		for tag, val := range influxResult.Tags {
+			r[tag] = val
 		}
+		r["InfluxMeasurement"] = influxResult.Name
+
+		influxData = append(influxData, r)
 	}
 
-	resultSlice.Set(resultSliceRet)
+	config := &mapstructure.DecoderConfig{
+		Metadata: nil,
+		Result: result,
+		TagName: "influx",
+		WeaklyTypedInput: false,
+		ZeroFields: false,
+		DecodeHook: func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+			if t == reflect.TypeOf(time.Time{}) && f == reflect.TypeOf("") {
+				return time.Parse(time.RFC3339, data.(string))
+			}
 
-	if len(errs) > 0 {
-		return &Error{errs}
+			return data, nil
+		},
 	}
 
-	return nil
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(influxData)
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -88,10 +88,8 @@ func TestDecodeMissingColumn(t *testing.T) {
 	decoded := []DecodeType{}
 
 	err := decode(columns, values, &decoded)
-	if err == nil {
-		t.Error("Expected error decoding: ", err)
-	} else {
-		fmt.Println("Got expected error: ", err)
+	if err != nil {
+		t.Error("UnExpected error decoding: ", columns, values, &decoded)
 	}
 
 	if !reflect.DeepEqual(expected, decoded) {

--- a/encode.go
+++ b/encode.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func encode(d interface{}) (t time.Time, tags map[string]string, fields map[string]interface{}, measurement string, err error) {
+func encode(d interface{}, timeField *usingValue) (t time.Time, tags map[string]string, fields map[string]interface{}, measurement string, err error) {
 	tags = make(map[string]string)
 	fields = make(map[string]interface{})
 	dValue := reflect.ValueOf(d)
@@ -19,6 +19,10 @@ func encode(d interface{}) (t time.Time, tags map[string]string, fields map[stri
 	if dValue.Kind() != reflect.Struct {
 		err = errors.New("data must be a struct")
 		return
+	}
+
+	if timeField == nil {
+		timeField = &usingValue{"time", false}
 	}
 
 	for i := 0; i < dValue.NumField(); i++ {
@@ -35,7 +39,7 @@ func encode(d interface{}) (t time.Time, tags map[string]string, fields map[stri
 			continue
 		}
 
-		if fieldData.fieldName == "time" {
+		if fieldData.fieldName == timeField.value {
 			// TODO error checking
 			t = f.Interface().(time.Time)
 			continue

--- a/encode.go
+++ b/encode.go
@@ -2,12 +2,12 @@ package influxdbhelper
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"time"
 )
 
-func encode(d interface{}) (t time.Time, tags map[string]string,
-	fields map[string]interface{}, err error) {
+func encode(d interface{}) (t time.Time, tags map[string]string, fields map[string]interface{}, err error) {
 	tags = make(map[string]string)
 	fields = make(map[string]interface{})
 	dValue := reflect.ValueOf(d)
@@ -18,25 +18,26 @@ func encode(d interface{}) (t time.Time, tags map[string]string,
 
 	for i := 0; i < dValue.NumField(); i++ {
 		f := dValue.Field(i)
+		fieldName := dValue.Type().Field(i).Name
 		fieldTag := dValue.Type().Field(i).Tag.Get("influx")
+		fieldData := getInfluxFieldTagData(fieldName, fieldTag)
 
-		isTag := isInfluxTag(fieldTag)
-		name := getInfluxFieldTagName(fieldTag)
-
-		if name == "-" {
+		if fieldData.fieldName == "-" {
 			continue
 		}
 
-		if name == "time" {
+		if fieldData.fieldName == "time" {
 			// TODO error checking
 			t = f.Interface().(time.Time)
 			continue
 		}
 
-		if isTag {
-			tags[name] = f.String()
-		} else {
-			fields[name] = f.Interface()
+		if fieldData.isTag {
+			tags[fieldData.fieldName] = fmt.Sprintf("%v", f)
+		}
+
+		if fieldData.isField {
+			fields[fieldData.fieldName] = f.Interface()
 		}
 	}
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -74,14 +74,14 @@ func TestEncode(t *testing.T) {
 		"StructFieldName":  d.StructFieldName,
 	}
 
-	tm, tags, fields, mesurement, err := encode(d)
+	tm, tags, fields, measurement, err := encode(d)
 
 	if err != nil {
 		t.Error("Error encoding: ", err)
 	}
 
-	if mesurement != d.InfluxMeasurement {
-		t.Errorf("%v != %v", mesurement, d.InfluxMeasurement)
+	if measurement != d.InfluxMeasurement {
+		t.Errorf("%v != %v", measurement, d.InfluxMeasurement)
 	}
 
 	if _, ok := fields["InfluxMeasurement"]; ok {

--- a/encode_test.go
+++ b/encode_test.go
@@ -15,36 +15,43 @@ func TestEncodeDataNotStruct(t *testing.T) {
 
 func TestEncode(t *testing.T) {
 	type MyType struct {
-		Time         time.Time `influx:"time"`
-		TagValue     string    `influx:"tagValue,tag"`
-		IntValue     int       `influx:"intValue"`
-		FloatValue   float64   `influx:"floatValue"`
-		BoolValue    bool      `influx:"boolValue"`
-		StringValue  string    `influx:"stringValue"`
-		IgnoredValue string    `influx:"-"`
+		Time             time.Time `influx:"time"`
+		TagValue         string    `influx:"tagValue,tag"`
+		TagAndFieldValue string    `influx:"tagAndFieldValue,tag,field"`
+		IntValue         int       `influx:"intValue"`
+		FloatValue       float64   `influx:"floatValue"`
+		BoolValue        bool      `influx:"boolValue"`
+		StringValue      string    `influx:"stringValue"`
+		StructFieldName  string    `influx:""`
+		IgnoredValue     string    `influx:"-"`
 	}
 
 	d := MyType{
 		time.Now(),
 		"tag-value",
+		"tag-and-field-value",
 		10,
 		10.5,
 		true,
 		"string",
+		"struct-field",
 		"ignored",
 	}
 
 	timeExp := d.Time
 
 	tagsExp := map[string]string{
-		"tagValue": "tag-value",
+		"tagValue":         "tag-value",
+		"tagAndFieldValue": "tag-and-field-value",
 	}
 
 	fieldsExp := map[string]interface{}{
-		"intValue":    d.IntValue,
-		"floatValue":  d.FloatValue,
-		"boolValue":   d.BoolValue,
-		"stringValue": d.StringValue,
+		"tagAndFieldValue": d.TagAndFieldValue,
+		"intValue":         d.IntValue,
+		"floatValue":       d.FloatValue,
+		"boolValue":        d.BoolValue,
+		"stringValue":      d.StringValue,
+		"StructFieldName":  d.StructFieldName,
 	}
 
 	tm, tags, fields, err := encode(d)

--- a/encode_test.go
+++ b/encode_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestEncodeDataNotStruct(t *testing.T) {
-	_, _, _, _, err := encode([]int{1, 2, 3})
+	_, _, _, _, err := encode([]int{1, 2, 3}, nil)
 	if err == nil {
 		t.Error("Expected error")
 	}
@@ -19,16 +19,35 @@ func TestEncodeSetsMesurment(t *testing.T) {
 	}
 
 	d := &MyType{"test-data"}
-	_, _, _, mesurement, err := encode(d)
+	_, _, _, measurement, err := encode(d, nil)
 
 	if err != nil {
 		t.Error("Error encoding: ", err)
 	}
 
-	if mesurement != "MyType" {
-		t.Errorf("%v != %v", mesurement, "MyType")
+	if measurement != "MyType" {
+		t.Errorf("%v != %v", measurement, "MyType")
+	}
+}
+
+func TestEncodeUsesTimeField(t *testing.T) {
+	type MyType struct {
+		MyTimeField             time.Time `influx:"my_time_field"`
+		Val string `influx:"val"`
 	}
 
+	td, _ := time.Parse(time.RFC822, "27 Oct 78 15:04 PST")
+
+	d := &MyType{td,"test-data"}
+	tv, _, _, _, err := encode(d, &usingValue{"my_time_field", false})
+
+	if tv != td {
+		t.Error("Did not properly use the time field specified")
+	}
+
+	if err != nil {
+		t.Error("Error encoding: ", err)
+	}
 }
 
 func TestEncode(t *testing.T) {
@@ -74,7 +93,7 @@ func TestEncode(t *testing.T) {
 		"StructFieldName":  d.StructFieldName,
 	}
 
-	tm, tags, fields, measurement, err := encode(d)
+	tm, tags, fields, measurement, err := encode(d, nil)
 
 	if err != nil {
 		t.Error("Error encoding: ", err)

--- a/examples/writeread.go
+++ b/examples/writeread.go
@@ -48,7 +48,7 @@ type envSample struct {
 type envSampleRead struct {
 	Time        time.Time `influx:"time"`
 	Location    string    `influx:"location,tag"`
-	City        string    `influx:"city,tag"`
+	City        string    `influx:"city,tag,field"`
 	Temperature float64   `influx:"temperature"`
 	Humidity    float64   `influx:"humidity"`
 	Cycles      float64   `influx:"cycles"`

--- a/examples/writeread.go
+++ b/examples/writeread.go
@@ -1,102 +1,102 @@
 package main
-//
-//import (
-//	"log"
-//	"time"
-//
-//	"github.com/cbrake/influxdbhelper"
-//	client "github.com/influxdata/influxdb/client/v2"
-//)
-//
-//const (
-//	// Static connection configuration
-//	influxURL = "http://localhost:8086"
-//	db        = "dbhelper"
-//)
-//
-//var c influxdbhelper.Client
-//
-//// Init initializes the database connection
-//func Init() (err error) {
-//	c, err = influxdbhelper.NewClient(influxURL, "", "", "ns")
-//	if err != nil {
-//		return
-//	}
-//	// Create MM database if it doesn't already exist
-//	q := client.NewQuery("CREATE DATABASE "+db, "", "")
-//	res, err := c.InfluxClient().Query(q)
-//	if err != nil {
-//		return err
-//	}
-//	if res.Error() != nil {
-//		return res.Error()
-//	}
-//	log.Println("dbhelper db initialized")
-//	return nil
-//}
-//
-//type envSample struct {
-//	InfluxMeasurement      influxdbhelper.Measurement
-//	Time        time.Time `influx:"time"`
-//	Location    string    `influx:"location,tag"`
-//	Temperature float64   `influx:"temperature"`
-//	Humidity    float64   `influx:"humidity"`
-//	ID          string    `influx:"-"`
-//}
-//
-//// we populate a few more fields when reading back
-//// date to verify unused fields are handled correctly
-//type envSampleRead struct {
-//	InfluxMeasurement      influxdbhelper.Measurement
-//	Time        time.Time `influx:"time"`
-//	Location    string    `influx:"location,tag"`
-//	City        string    `influx:"city,tag,field"`
-//	Temperature float64   `influx:"temperature"`
-//	Humidity    float64   `influx:"humidity"`
-//	Cycles      float64   `influx:"cycles"`
-//	ID          string    `influx:"-"`
-//}
-//
-//func generateSampleData() []envSample {
-//	ret := make([]envSample, 10)
-//
-//	for i := range ret {
-//		ret[i] = envSample{
-//			InfluxMeasurement: "test",
-//			Time:        time.Now(),
-//			Location:    "Rm 243",
-//			Temperature: 70 + float64(i),
-//			Humidity:    60 - float64(i),
-//			ID:          "12432as32",
-//		}
-//	}
-//
-//	return ret
-//}
-//
-//func main() {
-//	err := Init()
-//	if err != nil {
-//		log.Fatal("Failed to initialize db")
-//	}
-//
-//	// write sample data to database
-//	samples := generateSampleData()
-//	c = c.UseDB(db)
-//	for _, p := range samples {
-//		err := c.WritePoint(p)
-//		if err != nil {
-//			log.Fatal("Error writing point: ", err)
-//		}
-//	}
-//
-//	// query data from db
-//	samplesRead := []envSampleRead{}
-//
-//	q := `SELECT * FROM test ORDER BY time DESC LIMIT 10`
-//	err = c.UseDB(db).Query(q, &samplesRead)
-//	if err != nil {
-//		log.Fatal("Query error: ", err)
-//	}
-//	log.Printf("Samples read: %+v\n", samplesRead)
-//}
+
+import (
+	"log"
+	"time"
+
+	"github.com/cbrake/influxdbhelper"
+	client "github.com/influxdata/influxdb/client/v2"
+)
+
+const (
+	// Static connection configuration
+	influxURL = "http://localhost:8086"
+	db        = "dbhelper"
+)
+
+var c influxdbhelper.Client
+
+// Init initializes the database connection
+func Init() (err error) {
+	c, err = influxdbhelper.NewClient(influxURL, "", "", "ns")
+	if err != nil {
+		return
+	}
+	// Create MM database if it doesn't already exist
+	q := client.NewQuery("CREATE DATABASE "+db, "", "")
+	res, err := c.Query(q)
+	if err != nil {
+		return err
+	}
+	if res.Error() != nil {
+		return res.Error()
+	}
+	log.Println("dbhelper db initialized")
+	return nil
+}
+
+type envSample struct {
+	InfluxMeasurement      influxdbhelper.Measurement
+	Time        time.Time `influx:"time"`
+	Location    string    `influx:"location,tag"`
+	Temperature float64   `influx:"temperature"`
+	Humidity    float64   `influx:"humidity"`
+	ID          string    `influx:"-"`
+}
+
+// we populate a few more fields when reading back
+// date to verify unused fields are handled correctly
+type envSampleRead struct {
+	InfluxMeasurement      influxdbhelper.Measurement
+	Time        time.Time `influx:"time"`
+	Location    string    `influx:"location,tag"`
+	City        string    `influx:"city,tag,field"`
+	Temperature float64   `influx:"temperature"`
+	Humidity    float64   `influx:"humidity"`
+	Cycles      float64   `influx:"cycles"`
+	ID          string    `influx:"-"`
+}
+
+func generateSampleData() []envSample {
+	ret := make([]envSample, 10)
+
+	for i := range ret {
+		ret[i] = envSample{
+			InfluxMeasurement: "test",
+			Time:        time.Now(),
+			Location:    "Rm 243",
+			Temperature: 70 + float64(i),
+			Humidity:    60 - float64(i),
+			ID:          "12432as32",
+		}
+	}
+
+	return ret
+}
+
+func main() {
+	err := Init()
+	if err != nil {
+		log.Fatal("Failed to initialize db")
+	}
+
+	// write sample data to database
+	samples := generateSampleData()
+	c = c.UseDB(db)
+	for _, p := range samples {
+		err := c.WritePoint(p)
+		if err != nil {
+			log.Fatal("Error writing point: ", err)
+		}
+	}
+
+	// query data from db
+	samplesRead := []envSampleRead{}
+
+	q := `SELECT * FROM test ORDER BY time DESC LIMIT 10`
+	err = c.UseDB(db).DecodeQuery(q, &samplesRead)
+	if err != nil {
+		log.Fatal("Query error: ", err)
+	}
+	log.Printf("Samples read: %+v\n", samplesRead)
+}

--- a/examples/writeread.go
+++ b/examples/writeread.go
@@ -1,98 +1,102 @@
 package main
-
-import (
-	"log"
-	"time"
-
-	"github.com/cbrake/influxdbhelper"
-	client "github.com/influxdata/influxdb/client/v2"
-)
-
-const (
-	// Static connection configuration
-	influxURL = "http://localhost:8086"
-	db        = "dbhelper"
-)
-
-var c *influxdbhelper.Client
-
-// Init initializes the database connection
-func Init() (err error) {
-	c, err = influxdbhelper.NewClient(influxURL, "", "", "ns")
-	if err != nil {
-		return
-	}
-	// Create MM database if it doesn't already exist
-	q := client.NewQuery("CREATE DATABASE "+db, "", "")
-	res, err := c.InfluxClient().Query(q)
-	if err != nil {
-		return err
-	}
-	if res.Error() != nil {
-		return res.Error()
-	}
-	log.Println("dbhelper db initialized")
-	return nil
-}
-
-type envSample struct {
-	Time        time.Time `influx:"time"`
-	Location    string    `influx:"location,tag"`
-	Temperature float64   `influx:"temperature"`
-	Humidity    float64   `influx:"humidity"`
-	ID          string    `influx:"-"`
-}
-
-// we populate a few more fields when reading back
-// date to verify unused fields are handled correctly
-type envSampleRead struct {
-	Time        time.Time `influx:"time"`
-	Location    string    `influx:"location,tag"`
-	City        string    `influx:"city,tag,field"`
-	Temperature float64   `influx:"temperature"`
-	Humidity    float64   `influx:"humidity"`
-	Cycles      float64   `influx:"cycles"`
-	ID          string    `influx:"-"`
-}
-
-func generateSampleData() []envSample {
-	ret := make([]envSample, 10)
-
-	for i := range ret {
-		ret[i] = envSample{
-			Time:        time.Now(),
-			Location:    "Rm 243",
-			Temperature: 70 + float64(i),
-			Humidity:    60 - float64(i),
-			ID:          "12432as32",
-		}
-	}
-
-	return ret
-}
-
-func main() {
-	err := Init()
-	if err != nil {
-		log.Fatal("Failed to initialize db")
-	}
-
-	// write sample data to database
-	samples := generateSampleData()
-	for _, p := range samples {
-		err := c.WritePoint(db, "test", p)
-		if err != nil {
-			log.Fatal("Error writing point: ", err)
-		}
-	}
-
-	// query data from db
-	samplesRead := []envSampleRead{}
-
-	q := `SELECT * FROM test ORDER BY time DESC LIMIT 10`
-	err = c.Query(db, q, &samplesRead)
-	if err != nil {
-		log.Fatal("Query error: ", err)
-	}
-	log.Printf("Samples read: %+v\n", samplesRead)
-}
+//
+//import (
+//	"log"
+//	"time"
+//
+//	"github.com/cbrake/influxdbhelper"
+//	client "github.com/influxdata/influxdb/client/v2"
+//)
+//
+//const (
+//	// Static connection configuration
+//	influxURL = "http://localhost:8086"
+//	db        = "dbhelper"
+//)
+//
+//var c influxdbhelper.Client
+//
+//// Init initializes the database connection
+//func Init() (err error) {
+//	c, err = influxdbhelper.NewClient(influxURL, "", "", "ns")
+//	if err != nil {
+//		return
+//	}
+//	// Create MM database if it doesn't already exist
+//	q := client.NewQuery("CREATE DATABASE "+db, "", "")
+//	res, err := c.InfluxClient().Query(q)
+//	if err != nil {
+//		return err
+//	}
+//	if res.Error() != nil {
+//		return res.Error()
+//	}
+//	log.Println("dbhelper db initialized")
+//	return nil
+//}
+//
+//type envSample struct {
+//	InfluxMeasurement      influxdbhelper.Measurement
+//	Time        time.Time `influx:"time"`
+//	Location    string    `influx:"location,tag"`
+//	Temperature float64   `influx:"temperature"`
+//	Humidity    float64   `influx:"humidity"`
+//	ID          string    `influx:"-"`
+//}
+//
+//// we populate a few more fields when reading back
+//// date to verify unused fields are handled correctly
+//type envSampleRead struct {
+//	InfluxMeasurement      influxdbhelper.Measurement
+//	Time        time.Time `influx:"time"`
+//	Location    string    `influx:"location,tag"`
+//	City        string    `influx:"city,tag,field"`
+//	Temperature float64   `influx:"temperature"`
+//	Humidity    float64   `influx:"humidity"`
+//	Cycles      float64   `influx:"cycles"`
+//	ID          string    `influx:"-"`
+//}
+//
+//func generateSampleData() []envSample {
+//	ret := make([]envSample, 10)
+//
+//	for i := range ret {
+//		ret[i] = envSample{
+//			InfluxMeasurement: "test",
+//			Time:        time.Now(),
+//			Location:    "Rm 243",
+//			Temperature: 70 + float64(i),
+//			Humidity:    60 - float64(i),
+//			ID:          "12432as32",
+//		}
+//	}
+//
+//	return ret
+//}
+//
+//func main() {
+//	err := Init()
+//	if err != nil {
+//		log.Fatal("Failed to initialize db")
+//	}
+//
+//	// write sample data to database
+//	samples := generateSampleData()
+//	c = c.UseDB(db)
+//	for _, p := range samples {
+//		err := c.WritePoint(p)
+//		if err != nil {
+//			log.Fatal("Error writing point: ", err)
+//		}
+//	}
+//
+//	// query data from db
+//	samplesRead := []envSampleRead{}
+//
+//	q := `SELECT * FROM test ORDER BY time DESC LIMIT 10`
+//	err = c.UseDB(db).Query(q, &samplesRead)
+//	if err != nil {
+//		log.Fatal("Query error: ", err)
+//	}
+//	log.Printf("Samples read: %+v\n", samplesRead)
+//}

--- a/tag.go
+++ b/tag.go
@@ -2,26 +2,32 @@ package influxdbhelper
 
 import "strings"
 
-func isInfluxTag(structTag string) bool {
+type influxFieldTagData struct {
+	fieldName string
+	isTag     bool
+	isField   bool
+}
+
+func getInfluxFieldTagData(fieldName, structTag string) (fieldData *influxFieldTagData) {
+	fieldData = &influxFieldTagData{fieldName: fieldName}
 	parts := strings.Split(structTag, ",")
+	fieldName, parts = parts[0], parts[1:]
+	if fieldName != "" {
+		fieldData.fieldName = fieldName
+	}
 
 	for _, part := range parts {
 		if part == "tag" {
-			return true
+			fieldData.isTag = true
+		}
+		if part == "field" {
+			fieldData.isField = true
 		}
 	}
 
-	return false
-}
-
-func getInfluxFieldTagName(structTag string) string {
-	parts := strings.Split(structTag, ",")
-
-	for _, part := range parts {
-		if part != "tag" {
-			return part
-		}
+	if !fieldData.isField && !fieldData.isTag {
+		fieldData.isField = true
 	}
 
-	return ""
+	return
 }

--- a/tag.go
+++ b/tag.go
@@ -1,6 +1,10 @@
 package influxdbhelper
 
-import "strings"
+import (
+	"strings"
+)
+
+type Measurement = string
 
 type influxFieldTagData struct {
 	fieldName string

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,0 +1,38 @@
+package influxdbhelper
+
+import "testing"
+
+func TestTag(t *testing.T) {
+	data := []struct {
+		fieldTag        string
+		structFieldName string
+		fieldName       string
+		isTag           bool
+		isField         bool
+	}{
+		{"", "Test", "Test", false, true},
+		{"", "Test", "Test", false, true},
+		{",tag", "Test", "Test", true, false},
+		{",field,tag", "Test", "Test", true, true},
+		{",tag,field", "Test", "Test", true, true},
+		{",field", "Test", "Test", false, true},
+		{"test", "Test", "test", false, true},
+		{"test,tag", "Test", "test", true, false},
+		{"test,field,tag", "Test", "test", true, true},
+		{"test,tag,field", "Test", "test", true, true},
+		{"test,field", "Test", "test", false, true},
+	}
+
+	for _, testData := range data {
+		fieldData := getInfluxFieldTagData(testData.structFieldName, testData.fieldTag)
+		if fieldData.fieldName != testData.fieldName {
+			t.Errorf("%v != %v", fieldData.fieldName, testData.fieldName)
+		}
+		if fieldData.isField != testData.isField {
+			t.Errorf("%v != %v", fieldData.isField, testData.isField)
+		}
+		if fieldData.isTag != testData.isTag {
+			t.Errorf("%v != %v", fieldData.isTag, testData.isTag)
+		}
+	}
+}


### PR DESCRIPTION
* Make the client an interface that also implements the influx client interface
* refactor the decode to use the mapstruct decode instead of a fully custom decoder
* decode now works on a influxdb models.Row directly
* Add a Measurement type that has a required field name of InfluxMeasurement similar to XMLName, xml.Name in structs